### PR TITLE
Awsconnectionid templatize

### DIFF
--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -40,6 +40,8 @@ class AWSAthenaOperator(BaseOperator):
     :type output_location: str
     :param aws_conn_id: aws connection to use
     :type aws_conn_id: str
+          (adding this param to template_fields so that it can be overriden using jinja template from Dags
+           This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
     :param client_request_token: Unique token created by user to avoid multiple executions of same query
     :type client_request_token: str
     :param workgroup: Athena workgroup in which query will be run
@@ -55,7 +57,7 @@ class AWSAthenaOperator(BaseOperator):
     """
 
     ui_color = '#44b5e2'
-    template_fields = ('query', 'database', 'output_location')
+    template_fields = ('query', 'database', 'output_location' , 'aws_conn_id')
     template_ext = ('.sql',)
     template_fields_renderers = {"query": "sql"}
 

--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -38,8 +38,8 @@ class AWSAthenaOperator(BaseOperator):
     :type database: str
     :param output_location: s3 path to write the query results into. (templated)
     :type output_location: str
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags. 
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated). 
+    :type aws_conn_id: str
     :param client_request_token: Unique token created by user to avoid multiple executions of same query
     :type client_request_token: str
     :param workgroup: Athena workgroup in which query will be run

--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -38,8 +38,8 @@ class AWSAthenaOperator(BaseOperator):
     :type database: str
     :param output_location: s3 path to write the query results into. (templated)
     :type output_location: str
-    :param aws_conn_id: aws connection to use
-    :type aws_conn_id: <str> adding this param to template_fields so that it can be overriden using jinja template from Dags 
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags. 
+    :type aws_conn_id: <str>
     :param client_request_token: Unique token created by user to avoid multiple executions of same query
     :type client_request_token: str
     :param workgroup: Athena workgroup in which query will be run

--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -39,9 +39,7 @@ class AWSAthenaOperator(BaseOperator):
     :param output_location: s3 path to write the query results into. (templated)
     :type output_location: str
     :param aws_conn_id: aws connection to use
-    :type aws_conn_id: str
-          (adding this param to template_fields so that it can be overriden using jinja template from Dags
-           This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
+    :type aws_conn_id: <str> adding this param to template_fields so that it can be overriden using jinja template from Dags 
     :param client_request_token: Unique token created by user to avoid multiple executions of same query
     :type client_request_token: str
     :param workgroup: Athena workgroup in which query will be run
@@ -57,7 +55,7 @@ class AWSAthenaOperator(BaseOperator):
     """
 
     ui_color = '#44b5e2'
-    template_fields = ('query', 'database', 'output_location' , 'aws_conn_id')
+    template_fields = ('query', 'database', 'output_location','aws_conn_id')
     template_ext = ('.sql',)
     template_fields_renderers = {"query": "sql"}
 

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -67,9 +67,11 @@ class CloudFormationDeleteStackOperator(BaseOperator):
     :type params: dict
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
+         (Adding this param to template_fields so that it can be overriden using jinja template from Dags
+         This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     """
 
-    template_fields: List[str] = ['stack_name']
+    template_fields: List[str] = ['stack_name' , 'aws_conn_id']
     template_ext = ()
     ui_color = '#1d472b'
     ui_fgcolor = '#FFF'

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -33,7 +33,7 @@ class CloudFormationCreateStackOperator(BaseOperator):
         .. seealso::
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.create_stack
     :type params: dict
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :param aws_conn_id: aws connection to use (templated).
     :type aws_conn_id: str
     """
 
@@ -65,8 +65,8 @@ class CloudFormationDeleteStackOperator(BaseOperator):
         .. seealso::
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.delete_stack
     :type params: dict
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated).
+    :type aws_conn_id: str
     """
 
     template_fields: List[str] = ['stack_name','aws_conn_id']

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -66,12 +66,11 @@ class CloudFormationDeleteStackOperator(BaseOperator):
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.delete_stack
     :type params: dict
     :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: str
-         (Adding this param to template_fields so that it can be overriden using jinja template from Dags
-         This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+    :type aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
+                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     """
 
-    template_fields: List[str] = ['stack_name' , 'aws_conn_id']
+    template_fields: List[str] = ['stack_name','aws_conn_id']
     template_ext = ()
     ui_color = '#1d472b'
     ui_fgcolor = '#FFF'

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -33,11 +33,11 @@ class CloudFormationCreateStackOperator(BaseOperator):
         .. seealso::
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.create_stack
     :type params: dict
-    :param aws_conn_id: aws connection to uses
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
     :type aws_conn_id: str
     """
 
-    template_fields: List[str] = ['stack_name']
+    template_fields: List[str] = ['stack_name','aws_conn_id']
     template_ext = ()
     ui_color = '#6b9659'
 
@@ -65,9 +65,8 @@ class CloudFormationDeleteStackOperator(BaseOperator):
         .. seealso::
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.delete_stack
     :type params: dict
-    :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
-                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type aws_conn_id: <str>
     """
 
     template_fields: List[str] = ['stack_name','aws_conn_id']

--- a/airflow/providers/amazon/aws/operators/emr_add_steps.py
+++ b/airflow/providers/amazon/aws/operators/emr_add_steps.py
@@ -38,6 +38,8 @@ class EmrAddStepsOperator(BaseOperator):
     :type cluster_states: list
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
+         (adding this param to template_fields so that it can be overriden using jinja template from Dags
+           This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
     :param steps: boto3 style steps or reference to a steps file (must be '.json') to
         be added to the jobflow. (templated)
     :type steps: list|str
@@ -45,7 +47,7 @@ class EmrAddStepsOperator(BaseOperator):
     :type do_xcom_push: bool
     """
 
-    template_fields = ['job_flow_id', 'job_flow_name', 'cluster_states', 'steps']
+    template_fields = ['job_flow_id', 'job_flow_name', 'cluster_states', 'steps' , 'aws_conn_id']
     template_ext = ('.json',)
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/emr_add_steps.py
+++ b/airflow/providers/amazon/aws/operators/emr_add_steps.py
@@ -36,8 +36,8 @@ class EmrAddStepsOperator(BaseOperator):
     :param cluster_states: Acceptable cluster states when searching for JobFlow id by job_flow_name.
         (templated)
     :type cluster_states: list
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated).
+    :type aws_conn_id: str
     :param steps: boto3 style steps or reference to a steps file (must be '.json') to
         be added to the jobflow. (templated)
     :type steps: list|str

--- a/airflow/providers/amazon/aws/operators/emr_add_steps.py
+++ b/airflow/providers/amazon/aws/operators/emr_add_steps.py
@@ -37,9 +37,8 @@ class EmrAddStepsOperator(BaseOperator):
         (templated)
     :type cluster_states: list
     :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: str
-         (adding this param to template_fields so that it can be overriden using jinja template from Dags
-           This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
+    :type aws_conn_id: <str> adding this param to template_fields so that it can be overriden using jinja template from Dags.
+                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
     :param steps: boto3 style steps or reference to a steps file (must be '.json') to
         be added to the jobflow. (templated)
     :type steps: list|str
@@ -47,7 +46,7 @@ class EmrAddStepsOperator(BaseOperator):
     :type do_xcom_push: bool
     """
 
-    template_fields = ['job_flow_id', 'job_flow_name', 'cluster_states', 'steps' , 'aws_conn_id']
+    template_fields = ['job_flow_id', 'job_flow_name', 'cluster_states', 'steps','aws_conn_id']
     template_ext = ('.json',)
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/emr_add_steps.py
+++ b/airflow/providers/amazon/aws/operators/emr_add_steps.py
@@ -36,9 +36,8 @@ class EmrAddStepsOperator(BaseOperator):
     :param cluster_states: Acceptable cluster states when searching for JobFlow id by job_flow_name.
         (templated)
     :type cluster_states: list
-    :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: <str> adding this param to template_fields so that it can be overriden using jinja template from Dags.
-                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type aws_conn_id: <str>
     :param steps: boto3 style steps or reference to a steps file (must be '.json') to
         be added to the jobflow. (templated)
     :type steps: list|str

--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -31,6 +31,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
 
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
+       (adding this param to template_fields so that it can be overriden using jinja template from Dags
+       This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
     :param emr_conn_id: emr connection to use
     :type emr_conn_id: str
     :param job_flow_overrides: boto3 style arguments or reference to an arguments file
@@ -40,7 +42,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
     :type region_name: Optional[str]
     """
 
-    template_fields = ['job_flow_overrides']
+    template_fields = ['job_flow_overrides' , 'aws_conn_id']
     template_ext = ('.json',)
     template_fields_renderers = {"job_flow_overrides": "json"}
     ui_color = '#f9c915'

--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -42,7 +42,7 @@ class EmrCreateJobFlowOperator(BaseOperator):
     :type region_name: Optional[str]
     """
 
-    template_fields = ['job_flow_overrides' , 'aws_conn_id']
+    template_fields = ['job_flow_overrides','aws_conn_id']
     template_ext = ('.json',)
     template_fields_renderers = {"job_flow_overrides": "json"}
     ui_color = '#f9c915'

--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -29,9 +29,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
     A dictionary of JobFlow overrides can be passed that override
     the config from the connection.
 
-    :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: <str> adding this param to template_fields for jinja template use in the dags.
-                             This feature can be useful for some kind of Dag Isolation etc) 
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type aws_conn_id: <str>
     :param emr_conn_id: emr connection to use
     :type emr_conn_id: str
     :param job_flow_overrides: boto3 style arguments or reference to an arguments file

--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -31,8 +31,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
 
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
-       (adding this param to template_fields so that it can be overriden using jinja template from Dags
-       This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc) 
+       (adding this param to template_fields for jinja template use 
+        This feature can be useful for some kind of Dag Isolation etc) 
     :param emr_conn_id: emr connection to use
     :type emr_conn_id: str
     :param job_flow_overrides: boto3 style arguments or reference to an arguments file

--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -30,9 +30,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
     the config from the connection.
 
     :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: str
-       (adding this param to template_fields for jinja template use 
-        This feature can be useful for some kind of Dag Isolation etc) 
+    :type aws_conn_id: <str> adding this param to template_fields for jinja template use in the dags.
+                             This feature can be useful for some kind of Dag Isolation etc) 
     :param emr_conn_id: emr connection to use
     :type emr_conn_id: str
     :param job_flow_overrides: boto3 style arguments or reference to an arguments file

--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -29,8 +29,8 @@ class EmrCreateJobFlowOperator(BaseOperator):
     A dictionary of JobFlow overrides can be passed that override
     the config from the connection.
 
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated).
+    :type aws_conn_id: str
     :param emr_conn_id: emr connection to use
     :type emr_conn_id: str
     :param job_flow_overrides: boto3 style arguments or reference to an arguments file

--- a/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
+++ b/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
@@ -32,6 +32,8 @@ class EmrModifyClusterOperator(BaseOperator):
     :type step_concurrency_level: int
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
+        (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
+         This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param do_xcom_push: if True, cluster_id is pushed to XCom with key cluster_id.
     :type do_xcom_push: bool
     """

--- a/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
+++ b/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
@@ -30,7 +30,7 @@ class EmrModifyClusterOperator(BaseOperator):
     :type cluster_id: str
     :param step_concurrency_level: Concurrency of the cluster
     :type step_concurrency_level: int
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :param aws_conn_id: aws connection to use (templated).
     :type aws_conn_id: str
     :param do_xcom_push: if True, cluster_id is pushed to XCom with key cluster_id.
     :type do_xcom_push: bool

--- a/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
+++ b/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
@@ -30,15 +30,13 @@ class EmrModifyClusterOperator(BaseOperator):
     :type cluster_id: str
     :param step_concurrency_level: Concurrency of the cluster
     :type step_concurrency_level: int
-    :param aws_conn_id: aws connection to uses
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
     :type aws_conn_id: str
-        (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
-         This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param do_xcom_push: if True, cluster_id is pushed to XCom with key cluster_id.
     :type do_xcom_push: bool
     """
 
-    template_fields = ['cluster_id', 'step_concurrency_level' , 'aws_conn_id']
+    template_fields = ['cluster_id','step_concurrency_level','aws_conn_id']
     template_ext = ()
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
+++ b/airflow/providers/amazon/aws/operators/emr_modify_cluster.py
@@ -38,7 +38,7 @@ class EmrModifyClusterOperator(BaseOperator):
     :type do_xcom_push: bool
     """
 
-    template_fields = ['cluster_id', 'step_concurrency_level']
+    template_fields = ['cluster_id', 'step_concurrency_level' , 'aws_conn_id']
     template_ext = ()
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
@@ -31,9 +31,11 @@ class EmrTerminateJobFlowOperator(BaseOperator):
     :type job_flow_id: str
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
+       (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
+        This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     """
 
-    template_fields = ['job_flow_id']
+    template_fields = ['job_flow_id' , 'aws_conn_id']
     template_ext = ()
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
@@ -30,9 +30,8 @@ class EmrTerminateJobFlowOperator(BaseOperator):
     :param job_flow_id: id of the JobFlow to terminate. (templated)
     :type job_flow_id: str
     :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: str
-       (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
-        This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+    :type aws_conn_id: <str> Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
+                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
     """
 
     template_fields = ['job_flow_id' , 'aws_conn_id']

--- a/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
@@ -29,8 +29,8 @@ class EmrTerminateJobFlowOperator(BaseOperator):
 
     :param job_flow_id: id of the JobFlow to terminate. (templated)
     :type job_flow_id: str
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated).
+    :type aws_conn_id: str
     """
 
     template_fields = ['job_flow_id','aws_conn_id']

--- a/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_terminate_job_flow.py
@@ -29,12 +29,11 @@ class EmrTerminateJobFlowOperator(BaseOperator):
 
     :param job_flow_id: id of the JobFlow to terminate. (templated)
     :type job_flow_id: str
-    :param aws_conn_id: aws connection to uses
-    :type aws_conn_id: <str> Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
-                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type aws_conn_id: <str>
     """
 
-    template_fields = ['job_flow_id' , 'aws_conn_id']
+    template_fields = ['job_flow_id','aws_conn_id']
     template_ext = ()
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -37,12 +37,16 @@ class S3CreateBucketOperator(BaseOperator):
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
+        
+        Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
+        This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
+        
     :type aws_conn_id: Optional[str]
     :param region_name: AWS region_name. If not specified fetched from connection.
     :type region_name: Optional[str]
     """
 
-    template_fields = ("bucket_name",)
+    template_fields = ("bucket_name", "aws_conn_id")
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -36,7 +36,7 @@ class S3CreateBucketOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
-        maintained on each worker node).Also use in template_fields so that it can be overriden using jinja template from Dags.
+        maintained on each worker node).(templated).
     :type aws_conn_id: Optional[str]
     :param region_name: AWS region_name. If not specified fetched from connection.
     :type region_name: Optional[str]
@@ -83,7 +83,7 @@ class S3DeleteBucketOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
-        maintained on each worker node).Also use in template_fields so that it can be overriden using jinja template from Dags.
+        maintained on each worker node).(templated).
     :type aws_conn_id: Optional[str]
     """
 

--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -36,7 +36,7 @@ class S3CreateBucketOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
-        maintained on each worker node).
+        maintained on each worker node).Also use in template_fields so that it can be overriden using jinja template from Dags.
     :type aws_conn_id: Optional[str]
     :param region_name: AWS region_name. If not specified fetched from connection.
     :type region_name: Optional[str]
@@ -83,7 +83,7 @@ class S3DeleteBucketOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
-        maintained on each worker node).
+        maintained on each worker node).Also use in template_fields so that it can be overriden using jinja template from Dags.
     :type aws_conn_id: Optional[str]
     """
 

--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -37,16 +37,12 @@ class S3CreateBucketOperator(BaseOperator):
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
         maintained on each worker node).
-        
-        Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
-        This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
-        
     :type aws_conn_id: Optional[str]
     :param region_name: AWS region_name. If not specified fetched from connection.
     :type region_name: Optional[str]
     """
 
-    template_fields = ("bucket_name", "aws_conn_id")
+    template_fields = ("bucket_name","aws_conn_id")
 
     def __init__(
         self,
@@ -91,7 +87,7 @@ class S3DeleteBucketOperator(BaseOperator):
     :type aws_conn_id: Optional[str]
     """
 
-    template_fields = ("bucket_name",)
+    template_fields = ("bucket_name","aws_conn_id")
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
@@ -82,10 +82,14 @@ class S3PutBucketTaggingOperator(BaseOperator):
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then the default boto3 configuration would be used (and must be
         maintained on each worker node).
+        
+        Adding this param to template_fields so that it can be overriden using jinja template from Dags
+        This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
+
     :type aws_conn_id: Optional[str]
     """
 
-    template_fields = ("bucket_name",)
+    template_fields = ("bucket_name", "aws_conn_id")
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
@@ -34,15 +34,12 @@ class S3GetBucketTaggingOperator(BaseOperator):
 
     :param bucket_name: This is bucket name you want to reference
     :type bucket_name: str
-    :param aws_conn_id: The Airflow connection used for AWS credentials.
-        If this is None or empty then the default boto3 behaviour is used. If
-        running Airflow in a distributed manner and aws_conn_id is None or
-        empty, then default boto3 configuration would be used (and must be
-        maintained on each worker node).
+    :param aws_conn_id: adding this param to template_fields for jinja template use 
+        This feature can be useful for some kind of Dag Isolation etc 
     :type aws_conn_id: Optional[str]
     """
 
-    template_fields = ("bucket_name",)
+    template_fields = ("bucket_name","aws_conn_id")
 
     def __init__(self, bucket_name: str, aws_conn_id: Optional[str] = "aws_default", **kwargs) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
@@ -79,7 +79,6 @@ class S3PutBucketTaggingOperator(BaseOperator):
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then the default boto3 configuration would be used (and must be
         maintained on each worker node).
-        
         Adding this param to template_fields so that it can be overriden using jinja template from Dags
         This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
 

--- a/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
@@ -34,8 +34,7 @@ class S3GetBucketTaggingOperator(BaseOperator):
 
     :param bucket_name: This is bucket name you want to reference
     :type bucket_name: str
-    :param aws_conn_id: adding this param to template_fields for jinja template use.
-                             This feature can be useful for some kind of Dag Isolation etc 
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
     :type aws_conn_id: Optional[str]
     """
 
@@ -78,14 +77,11 @@ class S3PutBucketTaggingOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then the default boto3 configuration would be used (and must be
-        maintained on each worker node).
-        Adding this param to template_fields so that it can be overriden using jinja template from Dags
-        This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
-
+        maintained on each worker node).Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
     :type aws_conn_id: Optional[str]
     """
 
-    template_fields = ("bucket_name", "aws_conn_id")
+    template_fields = ("bucket_name","aws_conn_id")
 
     def __init__(
         self,
@@ -130,11 +126,11 @@ class S3DeleteBucketTaggingOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
-        maintained on each worker node).
+        maintained on each worker node).Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
     :type aws_conn_id: Optional[str]
     """
 
-    template_fields = ("bucket_name",)
+    template_fields = ("bucket_name","aws_conn_id")
 
     def __init__(self, bucket_name: str, aws_conn_id: Optional[str] = "aws_default", **kwargs) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
@@ -34,8 +34,8 @@ class S3GetBucketTaggingOperator(BaseOperator):
 
     :param bucket_name: This is bucket name you want to reference
     :type bucket_name: str
-    :param aws_conn_id: adding this param to template_fields for jinja template use 
-        This feature can be useful for some kind of Dag Isolation etc 
+    :param aws_conn_id: adding this param to template_fields for jinja template use.
+                             This feature can be useful for some kind of Dag Isolation etc 
     :type aws_conn_id: Optional[str]
     """
 

--- a/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket_tagging.py
@@ -34,7 +34,7 @@ class S3GetBucketTaggingOperator(BaseOperator):
 
     :param bucket_name: This is bucket name you want to reference
     :type bucket_name: str
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :param aws_conn_id: aws connection to use (templated).
     :type aws_conn_id: Optional[str]
     """
 
@@ -77,7 +77,7 @@ class S3PutBucketTaggingOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then the default boto3 configuration would be used (and must be
-        maintained on each worker node).Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+        maintained on each worker node). (templated).
     :type aws_conn_id: Optional[str]
     """
 
@@ -126,7 +126,7 @@ class S3DeleteBucketTaggingOperator(BaseOperator):
         If this is None or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
         empty, then default boto3 configuration would be used (and must be
-        maintained on each worker node).Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+        maintained on each worker node) (templated).
     :type aws_conn_id: Optional[str]
     """
 

--- a/airflow/providers/amazon/aws/operators/s3_copy_object.py
+++ b/airflow/providers/amazon/aws/operators/s3_copy_object.py
@@ -50,6 +50,8 @@ class S3CopyObjectOperator(BaseOperator):
     :type source_version_id: str
     :param aws_conn_id: Connection id of the S3 connection to use
     :type aws_conn_id: str
+         (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
+          This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 
@@ -67,7 +69,7 @@ class S3CopyObjectOperator(BaseOperator):
     :type acl_policy: str
     """
 
-    template_fields = ('source_bucket_key', 'dest_bucket_key', 'source_bucket_name', 'dest_bucket_name')
+    template_fields = ('source_bucket_key', 'dest_bucket_key', 'source_bucket_name', 'dest_bucket_name' , 'aws_conn_id')
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/s3_copy_object.py
+++ b/airflow/providers/amazon/aws/operators/s3_copy_object.py
@@ -49,9 +49,8 @@ class S3CopyObjectOperator(BaseOperator):
     :param source_version_id: Version ID of the source object (OPTIONAL)
     :type source_version_id: str
     :param aws_conn_id: Connection id of the S3 connection to use
-    :type aws_conn_id: str
-         adding this param to template_fields for jinja template use.
-         This feature can be useful for some kind of Dag Isolation etc
+    :type aws_conn_id: <str> adding this param to template_fields for jinja template use.
+                             This feature can be useful for some kind of Dag Isolation etc
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 

--- a/airflow/providers/amazon/aws/operators/s3_copy_object.py
+++ b/airflow/providers/amazon/aws/operators/s3_copy_object.py
@@ -50,8 +50,8 @@ class S3CopyObjectOperator(BaseOperator):
     :type source_version_id: str
     :param aws_conn_id: Connection id of the S3 connection to use
     :type aws_conn_id: str
-         (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
-          This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+         adding this param to template_fields for jinja template use.
+         This feature can be useful for some kind of Dag Isolation etc
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 
@@ -69,7 +69,7 @@ class S3CopyObjectOperator(BaseOperator):
     :type acl_policy: str
     """
 
-    template_fields = ('source_bucket_key', 'dest_bucket_key', 'source_bucket_name', 'dest_bucket_name' , 'aws_conn_id')
+    template_fields = ('source_bucket_key', 'dest_bucket_key', 'source_bucket_name', 'dest_bucket_name','aws_conn_id')
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/s3_copy_object.py
+++ b/airflow/providers/amazon/aws/operators/s3_copy_object.py
@@ -48,9 +48,8 @@ class S3CopyObjectOperator(BaseOperator):
     :type dest_bucket_name: str
     :param source_version_id: Version ID of the source object (OPTIONAL)
     :type source_version_id: str
-    :param aws_conn_id: Connection id of the S3 connection to use
-    :type aws_conn_id: <str> adding this param to template_fields for jinja template use.
-                             This feature can be useful for some kind of Dag Isolation etc
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type aws_conn_id: <str>
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 

--- a/airflow/providers/amazon/aws/operators/s3_copy_object.py
+++ b/airflow/providers/amazon/aws/operators/s3_copy_object.py
@@ -48,8 +48,8 @@ class S3CopyObjectOperator(BaseOperator):
     :type dest_bucket_name: str
     :param source_version_id: Version ID of the source object (OPTIONAL)
     :type source_version_id: str
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated).
+    :type aws_conn_id: str
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -45,6 +45,8 @@ class S3DeleteObjectsOperator(BaseOperator):
     :type prefix: str
     :param aws_conn_id: Connection id of the S3 connection to use
     :type aws_conn_id: str
+        (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
+         This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -43,8 +43,8 @@ class S3DeleteObjectsOperator(BaseOperator):
     :param prefix: Prefix of objects to delete. (templated)
         All objects matching this prefix in the bucket will be deleted.
     :type prefix: str
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated).
+    :type aws_conn_id: str
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -45,7 +45,7 @@ class S3DeleteObjectsOperator(BaseOperator):
     :type prefix: str
     :param aws_conn_id: Connection id of the S3 connection to use
     :type aws_conn_id: str
-        (Adding `aws_conn_id` param to template_fields so that it can be overriden using jinja template from Dags
+        (Adding this param to template_fields so that it can be overriden using jinja template from Dags
          This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
@@ -61,7 +61,7 @@ class S3DeleteObjectsOperator(BaseOperator):
     :type verify: bool or str
     """
 
-    template_fields = ('keys', 'bucket', 'prefix')
+    template_fields = ('keys', 'bucket', 'prefix' , 'aws_conn_id')
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -43,9 +43,8 @@ class S3DeleteObjectsOperator(BaseOperator):
     :param prefix: Prefix of objects to delete. (templated)
         All objects matching this prefix in the bucket will be deleted.
     :type prefix: str
-    :param aws_conn_id: Connection id of the S3 connection to use
-    :type aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
-                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type aws_conn_id: <str>
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 
@@ -60,7 +59,7 @@ class S3DeleteObjectsOperator(BaseOperator):
     :type verify: bool or str
     """
 
-    template_fields = ('keys', 'bucket', 'prefix' , 'aws_conn_id')
+    template_fields = ('keys','bucket','prefix','aws_conn_id')
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/s3_delete_objects.py
+++ b/airflow/providers/amazon/aws/operators/s3_delete_objects.py
@@ -44,9 +44,8 @@ class S3DeleteObjectsOperator(BaseOperator):
         All objects matching this prefix in the bucket will be deleted.
     :type prefix: str
     :param aws_conn_id: Connection id of the S3 connection to use
-    :type aws_conn_id: str
-        (Adding this param to template_fields so that it can be overriden using jinja template from Dags
-         This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+    :type aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
+                             This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
 

--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -55,6 +55,8 @@ class S3FileTransformOperator(BaseOperator):
     :type script_args: sequence of str
     :param source_aws_conn_id: source s3 connection
     :type source_aws_conn_id: str
+           (Adding this param to template_fields so that it can be overriden using jinja template from Dags
+            This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param source_verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:
@@ -70,6 +72,8 @@ class S3FileTransformOperator(BaseOperator):
     :type source_verify: bool or str
     :param dest_aws_conn_id: destination s3 connection
     :type dest_aws_conn_id: str
+          (Adding this param to template_fields so that it can be overriden using jinja template from Dags
+           This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
         See: ``source_verify``
     :type dest_verify: bool or str
@@ -77,7 +81,7 @@ class S3FileTransformOperator(BaseOperator):
     :type replace: bool
     """
 
-    template_fields = ('source_s3_key', 'dest_s3_key', 'script_args')
+    template_fields = ('source_s3_key', 'dest_s3_key', 'script_args' , 'source_aws_conn_id' , 'dest_aws_conn_id')
     template_ext = ()
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -54,9 +54,8 @@ class S3FileTransformOperator(BaseOperator):
     :param script_args: arguments for transformation script (templated)
     :type script_args: sequence of str
     :param source_aws_conn_id: source s3 connection
-    :type source_aws_conn_id: str
-           (Adding this param to template_fields so that it can be overriden using jinja template from Dags
-            This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+    :type source_aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
+                                    This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
     :param source_verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:
@@ -71,9 +70,8 @@ class S3FileTransformOperator(BaseOperator):
         This is also applicable to ``dest_verify``.
     :type source_verify: bool or str
     :param dest_aws_conn_id: destination s3 connection
-    :type dest_aws_conn_id: str
-          (Adding this param to template_fields so that it can be overriden using jinja template from Dags
-           This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+    :type dest_aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
+                                  This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
     :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
         See: ``source_verify``
     :type dest_verify: bool or str

--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -53,9 +53,8 @@ class S3FileTransformOperator(BaseOperator):
     :type select_expression: str
     :param script_args: arguments for transformation script (templated)
     :type script_args: sequence of str
-    :param source_aws_conn_id: source s3 connection
-    :type source_aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
-                                    This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
+    :param source_aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type source_aws_conn_id: <str>
     :param source_verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:
@@ -69,9 +68,8 @@ class S3FileTransformOperator(BaseOperator):
 
         This is also applicable to ``dest_verify``.
     :type source_verify: bool or str
-    :param dest_aws_conn_id: destination s3 connection
-    :type dest_aws_conn_id: <str> Adding this param to template_fields so that it can be overriden using jinja template from Dags
-                                  This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc
+    :param dest_aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type dest_aws_conn_id: <str>
     :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
         See: ``source_verify``
     :type dest_verify: bool or str
@@ -79,7 +77,7 @@ class S3FileTransformOperator(BaseOperator):
     :type replace: bool
     """
 
-    template_fields = ('source_s3_key', 'dest_s3_key', 'script_args' , 'source_aws_conn_id' , 'dest_aws_conn_id')
+    template_fields = ('source_s3_key','dest_s3_key','script_args','source_aws_conn_id','dest_aws_conn_id')
     template_ext = ()
     ui_color = '#f9c915'
 

--- a/airflow/providers/amazon/aws/operators/s3_file_transform.py
+++ b/airflow/providers/amazon/aws/operators/s3_file_transform.py
@@ -53,8 +53,8 @@ class S3FileTransformOperator(BaseOperator):
     :type select_expression: str
     :param script_args: arguments for transformation script (templated)
     :type script_args: sequence of str
-    :param source_aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type source_aws_conn_id: <str>
+    :param source_aws_conn_id: aws connection to use (templated).
+    :type source_aws_conn_id: str
     :param source_verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:
@@ -68,8 +68,8 @@ class S3FileTransformOperator(BaseOperator):
 
         This is also applicable to ``dest_verify``.
     :type source_verify: bool or str
-    :param dest_aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type dest_aws_conn_id: <str>
+    :param dest_aws_conn_id: aws connection to use (templated).
+    :type dest_aws_conn_id: str
     :param dest_verify: Whether or not to verify SSL certificates for S3 connection.
         See: ``source_verify``
     :type dest_verify: bool or str

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -38,6 +38,8 @@ class S3ListOperator(BaseOperator):
     :type delimiter: str
     :param aws_conn_id: The connection ID to use when connecting to S3 storage.
     :type aws_conn_id: str
+         (Adding this param to template_fields so that it can be overriden using jinja template from Dags
+          This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:
@@ -65,7 +67,7 @@ class S3ListOperator(BaseOperator):
             )
     """
 
-    template_fields: Iterable[str] = ('bucket', 'prefix', 'delimiter')
+    template_fields: Iterable[str] = ('bucket', 'prefix', 'delimiter' , 'aws_conn_id')
     ui_color = '#ffd700'
 
     def __init__(

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -36,9 +36,8 @@ class S3ListOperator(BaseOperator):
     :type prefix: str
     :param delimiter: the delimiter marks key hierarchy. (templated)
     :type delimiter: str
-    :param aws_conn_id: The connection ID to use when connecting to S3 storage.
-    :type aws_conn_id: <str> adding this param to template_fields for jinja template use.
-                             This feature can be useful for some kind of Dag Isolation etc
+    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
+    :type aws_conn_id: <str>
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -36,8 +36,8 @@ class S3ListOperator(BaseOperator):
     :type prefix: str
     :param delimiter: the delimiter marks key hierarchy. (templated)
     :type delimiter: str
-    :param aws_conn_id: Aws connection to use in template_fields so that it can be overriden using jinja template from Dags.
-    :type aws_conn_id: <str>
+    :param aws_conn_id: aws connection to use (templated).
+    :type aws_conn_id: str
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -38,8 +38,8 @@ class S3ListOperator(BaseOperator):
     :type delimiter: str
     :param aws_conn_id: The connection ID to use when connecting to S3 storage.
     :type aws_conn_id: str
-         (Adding this param to template_fields so that it can be overriden using jinja template from Dags
-          This feature can be useful if user wants to update/override the aws_conn_id for some kind of Dag Isolation etc)
+         adding this param to template_fields for jinja template use.
+         This feature can be useful for some kind of Dag Isolation etc
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:
@@ -67,7 +67,7 @@ class S3ListOperator(BaseOperator):
             )
     """
 
-    template_fields: Iterable[str] = ('bucket', 'prefix', 'delimiter' , 'aws_conn_id')
+    template_fields: Iterable[str] = ('bucket','prefix','delimiter','aws_conn_id')
     ui_color = '#ffd700'
 
     def __init__(

--- a/airflow/providers/amazon/aws/operators/s3_list.py
+++ b/airflow/providers/amazon/aws/operators/s3_list.py
@@ -37,9 +37,8 @@ class S3ListOperator(BaseOperator):
     :param delimiter: the delimiter marks key hierarchy. (templated)
     :type delimiter: str
     :param aws_conn_id: The connection ID to use when connecting to S3 storage.
-    :type aws_conn_id: str
-         adding this param to template_fields for jinja template use.
-         This feature can be useful for some kind of Dag Isolation etc
+    :type aws_conn_id: <str> adding this param to template_fields for jinja template use.
+                             This feature can be useful for some kind of Dag Isolation etc
     :param verify: Whether or not to verify SSL certificates for S3 connection.
         By default SSL certificates are verified.
         You can provide the following values:


### PR DESCRIPTION
Today since there is Dag Isolation provided as part of the airflow product , but dag users can generate aws_conn_id as seperate dag or some 3rd part system and pass back to original calling dag as part of XCOM variable , and should be able to over ride `aws_conn_id` param in AWS operators via Jinja template etc. But since `aws_conn_id` is not part of `template_fields` is all the AWS operators which makes dag users difficult to overide `aws_conn_id` param via XCOM variable using jinja template.

for example : as show in below code snippet , dag user can setup aws sts token into XCOM variable and fetch it using jinja template in `EmrCreateJobFlowOperator` operator

```
cluster_creator = EmrCreateJobFlowOperator(
        task_id='create_job_flow', 
        aws_conn_id="{{ task_instance.xcom_pull(task_ids='create_sts_connection', key='aws_conn_id') }}",
        job_flow_overrides=JOB_FLOW_OVERRIDES,
    )
```

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
